### PR TITLE
Install bc for debian

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -310,7 +310,7 @@ EOF
 		# headers were still downloadable and to provide suitable headers for future
 		# kernel updates.
 		apt-get install -y linux-headers-"$architecture"
-		apt-get install -y wireguard qrencode $firewall
+		apt-get install -y wireguard qrencode bc $firewall
 	elif [[ "$os" == "centos" && "$os_version" -eq 8 ]]; then
 		# CentOS 8
 		dnf install -y epel-release elrepo-release


### PR DESCRIPTION
Debian need bc installed 
```
DKMS make.log for wireguard-1.0.20200429 for kernel 4.19.0-8-amd64 (x86_64)
Sat 02 May 2020 10:19:34 AM WIB
make: Entering directory '/usr/src/linux-headers-4.19.0-8-amd64'
/bin/sh: 1: bc: not found
/var/lib/dkms/wireguard/1.0.20200429/build/compat/Kbuild.include:58: *** bc(1) is required for building.  Stop.
make[2]: *** [/usr/src/linux-headers-4.19.0-8-common/Makefile:1537: _module_/var/lib/dkms/wireguard/1.0.20200429/build] Error 2
make[1]: *** [Makefile:146: sub-make] Error 2
make: *** [Makefile:8: all] Error 2
make: Leaving directory '/usr/src/linux-headers-4.19.0-8-amd64'
```