### PR TITLE
Add 'Restart=on-failure' to wg-iptables systemd service

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -415,6 +415,8 @@ EOF
 Before=network.target
 [Service]
 Type=oneshot
+Restart=on-failure
+RestartSec=5s
 ExecStart=$iptables_path -t nat -A POSTROUTING -s 10.7.0.0/24 ! -d 10.7.0.0/24 -j SNAT --to $ip
 ExecStart=$iptables_path -I INPUT -p udp --dport $port -j ACCEPT
 ExecStart=$iptables_path -I FORWARD -s 10.7.0.0/24 -j ACCEPT


### PR DESCRIPTION
On my machine the service sometimes fails to start on boot-up, which causes no Internet access upon connecting to the VPN. This should fix it