### PR TITLE
Fix: Remove an existing client.

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -580,7 +580,7 @@ else
 				# Remove from the live interface
 				wg set wg0 peer "$(sed -n "/^# BEGIN_PEER $client$/,\$p" /etc/wireguard/wg0.conf | grep -m 1 PublicKey | cut -d " " -f 3)" remove
 				# Remove from the configuration file
-				sed -i "/^# BEGIN_PEER $client/,/^# END_PEER $client/d" /etc/wireguard/wg0.conf
+				sed -i "/^# BEGIN_PEER $client$/,/^# END_PEER $client$/d" /etc/wireguard/wg0.conf
 				echo
 				echo "$client removed!"
 			else


### PR DESCRIPTION
"Remove an existing client" may mistakenly remove multiple clients.
For example: remove client "test" will also remove client "test1".