### PR TITLE
Feat: support Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## wireguard-install
-WireGuard [road warrior](http://en.wikipedia.org/wiki/Road_warrior_%28computing%29) installer for Ubuntu, Debian, AlmaLinux, Rocky Linux, CentOS and Fedora.
+WireGuard [road warrior](http://en.wikipedia.org/wiki/Road_warrior_%28computing%29) installer for Ubuntu, Linux Mint, Debian, AlmaLinux, Rocky Linux, CentOS and Fedora.
 
 This script will let you set up your own VPN server in no more than a minute, even if you haven't used WireGuard before. It has been designed to be as unobtrusive and universal as possible.
 


### PR DESCRIPTION
Add support for Linux Mint. All actions are exactly the same as Ubuntu ones. Minimum supported version set to 19 (equivalent to Ubuntu 18.04). Tested on Linux Mint 20.3.