### PR TITLE
Add EuroLinux to supported distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## wireguard-install
-WireGuard [road warrior](http://en.wikipedia.org/wiki/Road_warrior_%28computing%29) installer for Ubuntu, Debian, AlmaLinux, Rocky Linux, CentOS and Fedora.
+WireGuard [road warrior](http://en.wikipedia.org/wiki/Road_warrior_%28computing%29) installer for Ubuntu, Debian, AlmaLinux, EuroLinux, Rocky Linux, CentOS and Fedora.
 
 This script will let you set up your own VPN server in no more than a minute, even if you haven't used WireGuard before. It has been designed to be as unobtrusive and universal as possible.
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -28,15 +28,15 @@ if grep -qs "ubuntu" /etc/os-release; then
 elif [[ -e /etc/debian_version ]]; then
 	os="debian"
 	os_version=$(grep -oE '[0-9]+' /etc/debian_version | head -1)
-elif [[ -e /etc/almalinux-release || -e /etc/rocky-release || -e /etc/centos-release ]]; then
+elif [[ -e /etc/almalinux-release || -e /etc/el-release || -e /etc/rocky-release || -e /etc/centos-release ]]; then
 	os="centos"
-	os_version=$(grep -shoE '[0-9]+' /etc/almalinux-release /etc/rocky-release /etc/centos-release | head -1)
+	os_version=$(grep -shoE '[0-9]+' /etc/almalinux-release /etc/el-release /etc/rocky-release /etc/centos-release | head -1)
 elif [[ -e /etc/fedora-release ]]; then
 	os="fedora"
 	os_version=$(grep -oE '[0-9]+' /etc/fedora-release | head -1)
 else
 	echo "This installer seems to be running on an unsupported distribution.
-Supported distros are Ubuntu, Debian, AlmaLinux, Rocky Linux, CentOS and Fedora."
+Supported distros are Ubuntu, Debian, AlmaLinux, EuroLinux, Rocky Linux, CentOS and Fedora."
 	exit
 fi
 


### PR DESCRIPTION
Add [EuroLinux](https://en.euro-linux.com/) (a RHEL replica) to supported distros alongside AlmaLinux, Rocky Linux and CentOS